### PR TITLE
make binding secret name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ stringData:
   tlsEnabled: "true"
 ```
 
-The format of the secret data can be overridden by specifying a go temmplate as `spec.binding.template`.
+The format of the secret data can be overridden by specifying a go template as `spec.binding.template`.
 In that go template, the following variables may be used:
 - `.sentinelEnabled` (whether sentinel mode is enabled or not)
 - `.masterHost`, `.masterPort`, `.replicaHost`, `.replicaPort` (only if sentinel is disabled)

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -91,7 +91,8 @@ type PersistenceProperties struct {
 
 // BindingProperties models custom properties for the generated binding secret
 type BindingProperties struct {
-	Template *string `json:"template,omitempty"`
+	SecretName string  `json:"secretName,omitempty"`
+	Template   *string `json:"template,omitempty"`
 }
 
 // RedisStatus defines the observed state of Redis

--- a/crds/cache.cs.sap.com_redis.yaml
+++ b/crds/cache.cs.sap.com_redis.yaml
@@ -970,6 +970,8 @@ spec:
                 description: BindingProperties models custom properties for the generated
                   binding secret
                 properties:
+                  secretName:
+                    type: string
                   template:
                     type: string
                 type: object

--- a/pkg/operator/binding.go
+++ b/pkg/operator/binding.go
@@ -82,7 +82,12 @@ func reconcileBinding(ctx context.Context, client client.Client, redis *operator
 	}
 
 	bindingSecret := &corev1.Secret{}
-	bindingSecretName := fmt.Sprintf("redis-%s-binding", redis.Name)
+	bindingSecretName := ""
+	if redis.Spec.Binding != nil && redis.Spec.Binding.SecretName != "" {
+		bindingSecretName = redis.Spec.Binding.SecretName
+	} else {
+		bindingSecretName = fmt.Sprintf("redis-%s-binding", redis.Name)
+	}
 	if err := client.Get(ctx, types.NamespacedName{Namespace: redis.Namespace, Name: bindingSecretName}, bindingSecret); err != nil {
 		return err
 	}

--- a/pkg/operator/data/parameters.yaml
+++ b/pkg/operator/data/parameters.yaml
@@ -9,7 +9,12 @@ fullnameOverride: {{ $fullname }}
 {{- $tlsEnabled := (dig "tls" "enabled" false .) }}
 {{- $persistenceEnabled := (dig "persistence" "enabled" false .) }}
 
-{{- with .Version}}
+{{- $bindingSecretName := (dig "binding" "secretName" "" .) }}
+{{- if eq $bindingSecretName "" }}
+{{- $bindingSecretName = printf "%s-binding" $fullname }}
+{{- end }}
+
+{{- with .version}}
 image:
   tag: {{ . }}
 {{- end }}
@@ -81,12 +86,10 @@ master:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
-  {{- if .sidecars }}
-  sidecars:
   {{- with .sidecars }}
+  sidecars:
     {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- end }}   
+  {{- end }} 
   
 replica:
   replicaCount: {{ ternary .replicas (max (sub .replicas 1) 0) $sentinelEnabled }}
@@ -142,12 +145,10 @@ replica:
     {{- toYaml . | nindent 4 }}
   {{- end }} 
   {{- end }}
-  {{- if .sidecars }}
-  sidecars:
   {{- with .sidecars }}
+  sidecars:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- end }}   
 
 {{- if $sentinelEnabled }}
 sentinel:
@@ -214,7 +215,7 @@ extraDeploy:
 - apiVersion: v1
   kind: Secret
   metadata:
-    name: {{ $fullname }}-binding
+    name: {{ $bindingSecretName }}
     annotations:
       helm.sh/hook: post-install
   type: Opaque


### PR DESCRIPTION
A new optional attribute is added: `spec.binding.secretName`; if specified the binding will be stored into this secret instead of the default `<name>-binding`.